### PR TITLE
fix(ci): unify AMD64 box integrity gate with ARM64

### DIFF
--- a/.github/workflows/build-amd64.yml
+++ b/.github/workflows/build-amd64.yml
@@ -125,8 +125,14 @@ jobs:
 
       - name: Verify Box File
         run: |
-          ls -lh packer/output-vagrant/ubuntu-${{ env.UBUNTU_VERSION }}-${{ matrix.filesystem }}-virtualbox-amd64.box
-          tar -tzf packer/output-vagrant/ubuntu-${{ env.UBUNTU_VERSION }}-${{ matrix.filesystem }}-virtualbox-amd64.box | head -10
+          BOX="packer/output-vagrant/ubuntu-${{ env.UBUNTU_VERSION }}-${{ matrix.filesystem }}-virtualbox-amd64.box"
+          if [ ! -f "$BOX" ]; then
+            echo "::error::Box file not found: $BOX (build truly failed)"; exit 1
+          fi
+          ls -lh "$BOX"
+          # Integrity: must be a valid gzip tar (catches truncation/partial export)
+          tar -tzf "$BOX" >/dev/null || { echo "::error::Box archive is corrupt: $BOX"; exit 1; }
+          echo "Box verified OK: $BOX"
 
       - name: Upload Box Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Follow-up to the code review on #1 (LOW item).

AMD64 `Verify Box File` used `tar -tzf ... | head -10`, which masks `tar`'s exit code (pipe to `head`), so a truncated/corrupt box could still pass verification and get published. ARM64 already has a hardened gate.

This applies the same explicit gate to AMD64: file-existence check + `tar -tzf "$BOX" >/dev/null || exit 1`. AMD64's packer build runs on Linux runners without the VBox-on-Silicon cleanup quirk, so no `|| echo` tolerance is added — only the integrity assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)