### PR TITLE
feat(sandbox): expose correlated effective enforcement evidence

### DIFF
--- a/.github/workflows/sandbox-enforcement-evidence.yml
+++ b/.github/workflows/sandbox-enforcement-evidence.yml
@@ -1,0 +1,31 @@
+name: Sandbox Enforcement Evidence
+
+on:
+  pull_request:
+    paths:
+      - "sandbox/**"
+      - "docs/evidence-contracts.md"
+      - ".github/workflows/sandbox-enforcement-evidence.yml"
+  push:
+    branches: [main]
+    paths:
+      - "sandbox/**"
+      - "docs/evidence-contracts.md"
+      - ".github/workflows/sandbox-enforcement-evidence.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Static checks
+        run: |
+          set -euo pipefail
+          bash -n sandbox/verify-sandbox-evidence.sh sandbox/test-enforcement-evidence-contract.sh
+          shellcheck --severity=warning sandbox/verify-sandbox-evidence.sh sandbox/test-enforcement-evidence-contract.sh
+      - name: Enforcement evidence contract test
+        run: bash sandbox/test-enforcement-evidence-contract.sh

--- a/docs/evidence-contracts.md
+++ b/docs/evidence-contracts.md
@@ -6,7 +6,7 @@ All readiness/security/diagnostic validators emit versioned JSON rather than hum
 |---|---|---|
 | `kube-ready-evidence/v1` | Rust verifier | node preflight + offline artifact verification |
 | `kube-ready-readiness/v1` | node readiness / NixOS / Rocky | Kubernetes node readiness |
-| `kube-ready-sandbox/v1` | sandbox artifact tooling | sandbox runtime evidence |
+| `kube-ready-sandbox/v1` | sandbox artifact tooling | sandbox runtime/effective-enforcement evidence |
 | `kube-ready-security/v1` | workload security tooling | AppArmor/SELinux/security intent |
 | `kube-ready-network/v1` | network profile | effective network state |
 | `kube-ready-storage/v1` | storage profile | storage/backend capability |
@@ -25,3 +25,22 @@ All readiness/security/diagnostic validators emit versioned JSON rather than hum
 A release can only claim a complete readiness result when the required profiles for its declared OS/provider/architecture/runtime/storage combination have no unresolved required `UNKNOWN` results.
 
 Evidence should be linked to the immutable box version and SHA256 digest. Offline replay must consume supplied artifacts only and must not install packages or query external services.
+
+## Enforcement provider boundary
+
+`kube-ready-box` is an **enforcement/evidence provider**, not an agent authorization source of truth. In particular, `kube-ready-sandbox/v1` separates these states:
+
+```text
+declared -> supported -> effective -> verified
+```
+
+- `declared`: the requested RuntimeClass exists and names a handler.
+- `supported`: the handler is one of the explicitly recognized sandbox runtime families.
+- `effective`: a workload using that RuntimeClass actually reaches a running container/runtime instance.
+- `verified`: effective runtime evidence is accompanied by the required security/resource checks and negative enforcement probe.
+
+The sandbox evidence producer may receive `RESOLUTION_ID` and `INVOCATION_DIGEST` from an upper execution-security layer. They are copied into `correlation` with `authoritySemantics: none-correlation-only`; their presence never authorizes execution and kube-ready-box does not recompute an upstream policy decision.
+
+Each emitted sandbox record also includes `evidenceDigest`, a SHA-256 digest over the canonical JSON evidence object before the digest field is added. Consumers can therefore bind the effective enforcement result to their own decision/invocation chain without making this node image the policy authority.
+
+The `missing-runtime-class` negative probe demonstrates the Kubernetes/runtime enforcement boundary. It explicitly does **not** prove that an upstream request was correctly authorized or denied; request-side authorization must be tested separately by the agent/control-plane repository.

--- a/sandbox/test-enforcement-evidence-contract.sh
+++ b/sandbox/test-enforcement-evidence-contract.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+cat >"$TMP/bin/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+args="$*"
+case "$args" in
+  "create namespace "*" --dry-run=client -o yaml")
+    printf '%s\n' 'apiVersion: v1' 'kind: Namespace' 'metadata:' '  name: test'
+    ;;
+  "apply -f -")
+    cat >/dev/null
+    ;;
+  "get runtimeclass gvisor -o json")
+    printf '%s\n' '{"apiVersion":"node.k8s.io/v1","kind":"RuntimeClass","metadata":{"name":"gvisor"},"handler":"runsc"}'
+    ;;
+  "-n kube-ready-sandbox-test apply -f -")
+    cat >/dev/null
+    ;;
+  "-n kube-ready-sandbox-test wait --for=condition=Ready pod/sandbox-evidence --timeout=120s")
+    ;;
+  "-n kube-ready-sandbox-test get pod sandbox-evidence -o jsonpath={.status.containerStatuses[0].containerID}")
+    printf '%s' 'containerd://fixture-container-id'
+    ;;
+  "-n kube-ready-sandbox-test exec sandbox-evidence -- sh -c "*)
+    printf '%s\n' 'NoNewPrivs: 1' 'Seccomp: 2' 'PID1=/pause'
+    ;;
+  "get runtimeclass kube-ready-negative-do-not-exist")
+    exit 1
+    ;;
+  "-n kube-ready-sandbox-test apply --dry-run=server -f -")
+    cat >/dev/null
+    printf '%s\n' 'RuntimeClass "kube-ready-negative-do-not-exist" not found' >&2
+    exit 1
+    ;;
+  "delete namespace kube-ready-sandbox-test --ignore-not-found")
+    ;;
+  *)
+    printf 'unexpected fake kubectl invocation: %s\n' "$args" >&2
+    exit 97
+    ;;
+esac
+FAKE
+chmod +x "$TMP/bin/kubectl"
+
+OUTPUT="$TMP/evidence.json"
+RESOLUTION_ID='resolution:test:123' \
+INVOCATION_DIGEST='sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' \
+PATH="$TMP/bin:$PATH" \
+OUTPUT="$OUTPUT" \
+bash "$ROOT/sandbox/verify-sandbox-evidence.sh" >/dev/null
+
+python3 - "$OUTPUT" <<'PY'
+import hashlib,json,sys
+p=sys.argv[1]
+data=json.load(open(p))
+assert data['schema']=='kube-ready-sandbox/v1'
+assert data['role']=='enforcement-evidence-provider'
+assert data['status']=='PASS'
+assert data['lifecycle']=={
+  'declared':'PASS','supported':'PASS','effective':'PASS','verified':'PASS'
+}
+assert data['checks']['missingRuntimeClassRejected']=='PASS'
+assert data['negativeProbe']['proves']=='runtime-enforcement-boundary'
+assert data['negativeProbe']['doesNotProve']=='request-side-authorization'
+assert data['correlation']['resolutionId']=='resolution:test:123'
+assert data['correlation']['invocationDigest']=='sha256:'+'a'*64
+assert data['correlation']['authoritySemantics']=='none-correlation-only'
+digest=data.pop('evidenceDigest')
+canonical=json.dumps(data,sort_keys=True,separators=(',',':'))
+assert digest=='sha256:'+hashlib.sha256(canonical.encode()).hexdigest()
+PY
+
+if RESOLUTION_ID='resolution:test:bad' INVOCATION_DIGEST='not-a-digest' PATH="$TMP/bin:$PATH" OUTPUT="$TMP/bad.json" \
+  bash "$ROOT/sandbox/verify-sandbox-evidence.sh" >/dev/null 2>&1; then
+  echo 'invalid invocation digest was accepted' >&2
+  exit 1
+fi
+
+echo 'sandbox enforcement evidence contract: PASS'

--- a/sandbox/verify-sandbox-evidence.sh
+++ b/sandbox/verify-sandbox-evidence.sh
@@ -6,11 +6,20 @@ RUNTIME_CLASS="${RUNTIME_CLASS:-gvisor}"
 NAMESPACE="${NAMESPACE:-kube-ready-sandbox-test}"
 OUTPUT="${OUTPUT:-sandbox-evidence.json}"
 IMAGE="${IMAGE:-busybox:1.36}"
+# Optional correlation supplied by an upper authorization/execution layer. kube-ready-box
+# records these values only; it never interprets them as authority to execute anything.
+RESOLUTION_ID="${RESOLUTION_ID:-}"
+INVOCATION_DIGEST="${INVOCATION_DIGEST:-}"
 FAILURES=0
 container_id=""
 
 command -v kubectl >/dev/null || { echo 'kubectl required' >&2; exit 2; }
 command -v python3 >/dev/null || { echo 'python3 required' >&2; exit 2; }
+
+if [ -n "$INVOCATION_DIGEST" ] && ! printf '%s' "$INVOCATION_DIGEST" | grep -Eq '^sha256:[0-9a-fA-F]{64}$'; then
+  echo 'INVOCATION_DIGEST must be sha256:<64 hex> when provided' >&2
+  exit 2
+fi
 
 check_runtimeclass() {
   kubectl get runtimeclass "$RUNTIME_CLASS" -o json >/tmp/runtimeclass.json 2>/dev/null || return 1
@@ -39,14 +48,18 @@ PY
 kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
 trap 'kubectl delete namespace "$NAMESPACE" --ignore-not-found >/dev/null 2>&1 || true' EXIT
 
-status_runtime="FAIL"
+status_declared="FAIL"
+status_supported="FAIL"
 status_effective="FAIL"
 status_security="FAIL"
 status_negative="FAIL"
 status_resources="FAIL"
 
-if check_runtimeclass && check_runtime_handler; then
-  status_runtime="PASS"
+if check_runtimeclass; then
+  status_declared="PASS"
+  if check_runtime_handler; then
+    status_supported="PASS"
+  fi
 fi
 
 cat <<EOF | kubectl -n "$NAMESPACE" apply -f - >/dev/null
@@ -86,7 +99,9 @@ if kubectl -n "$NAMESPACE" wait --for=condition=Ready pod/sandbox-evidence --tim
   [ -n "$container_id" ] && status_effective="PASS"
 fi
 
-# Negative test: a deliberately missing RuntimeClass must be rejected before execution.
+# Negative probe: a deliberately missing RuntimeClass must be rejected before workload execution.
+# This proves the Kubernetes/runtime-class enforcement boundary, not an upstream authorization
+# decision. Upper layers must verify request-side authorization separately.
 negative_class="kube-ready-negative-do-not-exist"
 if kubectl get runtimeclass "$negative_class" >/dev/null 2>&1; then
   kubectl delete runtimeclass "$negative_class" >/dev/null 2>&1 || true
@@ -108,7 +123,7 @@ else
   grep -qi 'RuntimeClass' /tmp/negative.out && status_negative="PASS" || status_negative="UNKNOWN"
 fi
 
-if [ "$status_runtime" != PASS ] || [ "$status_effective" != PASS ] || [ "$status_security" != PASS ] || [ "$status_negative" != PASS ] || [ "$status_resources" != PASS ]; then
+if [ "$status_declared" != PASS ] || [ "$status_supported" != PASS ] || [ "$status_effective" != PASS ] || [ "$status_security" != PASS ] || [ "$status_negative" != PASS ] || [ "$status_resources" != PASS ]; then
   FAILURES=$((FAILURES + 1))
 fi
 
@@ -121,24 +136,49 @@ except Exception:
 PY
 )"
 
-python3 - "$OUTPUT" "$RUNTIME_CLASS" "$runtime_handler" "$status_runtime" "$status_effective" "$status_security" "$status_resources" "$status_negative" "$FAILURES" "$container_id" <<'PY'
-import datetime,json,sys
-out,rc,handler,sr,se,ss,so,sn,failures,cid=sys.argv[1:]
+python3 - "$OUTPUT" "$RUNTIME_CLASS" "$runtime_handler" "$status_declared" "$status_supported" "$status_effective" "$status_security" "$status_resources" "$status_negative" "$FAILURES" "$container_id" "$RESOLUTION_ID" "$INVOCATION_DIGEST" <<'PY'
+import datetime,hashlib,json,sys
+(
+    out,rc,handler,declared,supported,effective,security,resources,negative,
+    failures,cid,resolution_id,invocation_digest
+)=sys.argv[1:]
 obj={
   'schema':'kube-ready-sandbox/v1',
+  'role':'enforcement-evidence-provider',
   'runtimeClass':rc,
   'handler':handler or None,
+  'lifecycle':{
+    'declared':declared,
+    'supported':supported,
+    'effective':effective,
+    'verified':'PASS' if security == 'PASS' and negative == 'PASS' and resources == 'PASS' else 'FAIL',
+  },
   'checks':{
-    'runtimeClass':sr,
-    'effectiveRuntime':se,
-    'seccompNoNewPrivs':ss,
-    'resourceIsolation':so,
-    'missingRuntimeClassRejected':sn,
+    # Keep legacy keys for existing consumers while exposing the explicit lifecycle above.
+    'runtimeClass':declared,
+    'runtimeHandlerSupported':supported,
+    'effectiveRuntime':effective,
+    'seccompNoNewPrivs':security,
+    'resourceIsolation':resources,
+    'missingRuntimeClassRejected':negative,
+  },
+  'negativeProbe':{
+    'name':'missing-runtime-class',
+    'status':negative,
+    'proves':'runtime-enforcement-boundary',
+    'doesNotProve':'request-side-authorization',
+  },
+  'correlation':{
+    'resolutionId':resolution_id or None,
+    'invocationDigest':invocation_digest or None,
+    'authoritySemantics':'none-correlation-only',
   },
   'containerIDPresent':bool(cid),
   'status':'PASS' if int(failures)==0 else 'FAIL',
   'generatedAt':datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00','Z')
 }
+canonical=json.dumps(obj,sort_keys=True,separators=(',',':'))
+obj['evidenceDigest']='sha256:'+hashlib.sha256(canonical.encode()).hexdigest()
 open(out,'w').write(json.dumps(obj,sort_keys=True,separators=(',',':'))+'\n')
 print(json.dumps(obj,sort_keys=True,separators=(',',':')))
 PY


### PR DESCRIPTION
## Summary

Align kube-ready-box sandbox evidence with the OpenForge Agent Execution Security provider boundary without turning the node image into an authorization source of truth.

- keep `kube-ready-sandbox/v1` backward compatible
- explicitly expose `declared -> supported -> effective -> verified` lifecycle state
- preserve legacy check keys for existing consumers
- record optional upper-layer `RESOLUTION_ID` / `INVOCATION_DIGEST` as correlation-only metadata
- reject malformed invocation digests rather than recording ambiguous evidence
- label kube-ready-box as `enforcement-evidence-provider`
- add canonical SHA-256 `evidenceDigest`
- make the negative probe explicit about what it proves (runtime enforcement) and what it does not prove (request-side authorization)
- add a Linux contract harness with fake kubectl to verify schema/correlation/digest/deny semantics without claiming real sandbox enforcement
- add permanent path-filtered CI for the sandbox evidence contract
- document the provider/authority boundary in `docs/evidence-contracts.md`

## Verification model

The new CI verifies the evidence producer's control flow and schema on Linux. It intentionally does **not** claim effective gVisor/Kata enforcement from a fake runtime. Real `effective` evidence still comes only from `sandbox/verify-sandbox-evidence.sh` running against a real Kubernetes node/runtime where the RuntimeClass Pod becomes Ready and the runtime/security probes succeed.

Related: #11, #16, #20, dasomel/openforge#37