### PR TITLE
ci(agent): validate agent contract changes

### DIFF
--- a/.github/workflows/agent-contract.yml
+++ b/.github/workflows/agent-contract.yml
@@ -1,0 +1,50 @@
+name: Agent Contract
+
+on:
+  pull_request:
+    paths:
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - '.agents/**'
+      - '.claude/**'
+      - '.github/workflows/agent-contract.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - '.agents/**'
+      - '.claude/**'
+      - '.github/workflows/agent-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: OpenForge agent contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Checkout pinned OpenForge auditor
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: dasomel/openforge
+          ref: 44d7efc01ed59d033ac0c774af46196149010702
+          path: .openforge-audit
+          sparse-checkout: |
+            templates/scripts/audit-agent-skills.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Validate Agent Skills and Claude adapter
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .openforge-audit/templates/scripts/audit-agent-skills.py .


### PR DESCRIPTION
## Summary

Add a lightweight Agent Contract workflow for instruction/skill-only changes. It runs the OpenForge Agent Skills auditor pinned to revision `44d7efc01ed59d033ac0c774af46196149010702` and does not trigger the expensive Packer/Rust/readiness matrix solely because `CLAUDE.md` or a project skill changed.

## Why

The latest agent-standardization main commit had zero Actions runs because `validate.yml` only watches product/build paths. This closes the repository-local validation gap tracked by OpenForge #72.

## Validation

- watches `AGENTS.md`, `CLAUDE.md`, `.agents/**`, `.claude/**`
- fail-closed OpenForge auditor
- pinned standards revision
- read-only permissions and non-persisted checkout credentials
- lightweight 5-minute job independent from the full box validation matrix
