### PR TITLE
docs: add verified implementation status snapshot

### DIFF
--- a/docs/IMPLEMENTATION-STATUS-ko.md
+++ b/docs/IMPLEMENTATION-STATUS-ko.md
@@ -1,0 +1,37 @@
+# 구현 상태
+
+Last verified: 2026-09-09 against `main`
+
+이 문서는 default branch에 실제 존재하는 동작의 snapshot이며 roadmap이 아닙니다.
+
+## 구현됨
+
+- Ubuntu 24.04 LTS / 26.04 LTS Kubernetes-ready base box 정의.
+- AMD64/ARM64 build target 및 문서화된 VirtualBox/VMware provider coverage.
+- ext4/XFS variant, boot-time disk extension, Kubernetes host tuning, diagnostics, security/readiness contract와 machine-readable evidence producer.
+- gVisor/runsc provisioning support, Kubernetes RuntimeClass, sandbox preflight/smoke tooling 및 `kube-ready-sandbox/v1` evidence를 포함한 optional sandbox profile 자산.
+- Sandbox evidence의 `declared`, `supported`, `effective`, `verified` 분리, negative RuntimeClass probe, authorization source가 되지 않는 correlation-only resolution/invocation metadata.
+- Packer, shell/static rules, Rust verifier, supply-chain, readiness/security contract와 sandbox evidence producer를 검증하는 CI.
+
+## 부분적 / 환경 의존
+
+- 실제 sandbox `effective` evidence는 configured RuntimeClass Pod가 실제 Kubernetes node에서 실행되고 runtime/security probe를 통과해야 합니다. Mock CI는 producer control flow/schema만 검증합니다.
+- 실제 VM에서 실행되지 않은 provider/architecture/runtime 조합은 template validation이 성공해도 runtime evidence가 제한적입니다.
+
+## 주장하지 않음
+
+- 표준 box에 Kubernetes/container runtime/CNI를 포함하지 않습니다.
+- Agent authorization source of truth 역할을 하지 않습니다.
+- Template validation만으로 실제 gVisor/kernel isolation을 증명했다고 주장하지 않습니다.
+
+## Evidence
+
+- `README.md`
+- `packer/`
+- `sandbox/README.md`
+- `sandbox/verify-sandbox-evidence.sh`
+- `security/workload-security-check.sh`
+- `rust/kube-ready-verifier/`
+- `.github/workflows/validate.yml`
+- `.github/workflows/sandbox-enforcement-evidence.yml`
+- PR #39 (`8bc654e1538daa46356e56237618f5718e4529ff`)

--- a/docs/IMPLEMENTATION-STATUS.md
+++ b/docs/IMPLEMENTATION-STATUS.md
@@ -1,0 +1,37 @@
+# Implementation Status
+
+Last verified: 2026-09-09 against `main`
+
+This is a snapshot of behavior present on the default branch, not a roadmap.
+
+## Implemented
+
+- Ubuntu 24.04 LTS and 26.04 LTS Kubernetes-ready base-box definitions.
+- AMD64 and ARM64 build targets with VirtualBox and VMware provider coverage as documented in the build matrix.
+- ext4 and XFS filesystem variants, boot-time disk extension, Kubernetes host tuning, diagnostics, security/readiness contracts, and machine-readable evidence producers.
+- Optional sandbox profile assets including gVisor/runsc provisioning support, Kubernetes RuntimeClass, sandbox preflight/smoke tooling, and `kube-ready-sandbox/v1` evidence.
+- Sandbox evidence distinguishes `declared`, `supported`, `effective`, and `verified`, includes negative RuntimeClass probing, and can carry upper-layer resolution/invocation correlation without becoming an authorization source.
+- CI validates Packer configurations, shell/static rules, Rust verifier behavior, supply-chain controls, readiness/security contracts, and the sandbox evidence producer.
+
+## Partial / environment-dependent
+
+- Real sandbox `effective` evidence requires a Kubernetes node where the configured RuntimeClass actually starts a Pod and the runtime/security probes succeed. Mock CI validates producer control flow/schema only.
+- Provider/architecture/runtime combinations that have not been exercised on a real VM remain evidence-limited even when their templates validate.
+
+## Not claimed
+
+- Kubernetes, a container runtime, or a CNI are not bundled as part of the standard box.
+- The project does not act as an agent authorization source of truth.
+- Template validation alone is not claimed as proof of real gVisor/kernel isolation.
+
+## Evidence
+
+- `README.md`
+- `packer/`
+- `sandbox/README.md`
+- `sandbox/verify-sandbox-evidence.sh`
+- `security/workload-security-check.sh`
+- `rust/kube-ready-verifier/`
+- `.github/workflows/validate.yml`
+- `.github/workflows/sandbox-enforcement-evidence.yml`
+- PR #39 (`8bc654e1538daa46356e56237618f5718e4529ff`)


### PR DESCRIPTION
## Summary

Add bilingual current-state implementation snapshots for OpenForge documentation-freshness auditing.

- binds the snapshot to `main` as of 2026-09-09
- separates implemented, environment-dependent, and not-claimed behavior
- distinguishes mock contract evidence from real sandbox/runtime enforcement

Related: dasomel/openforge#18, #74